### PR TITLE
test: Contact form, API mail mock, and consent-gated cookie UI

### DIFF
--- a/src/app/api/form/__tests__/route.test.ts
+++ b/src/app/api/form/__tests__/route.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+
+import { POST } from '../route';
+
+const sendMail = jest.fn();
+const use = jest.fn();
+
+jest.mock('nodemailer-express-handlebars', () => ({
+  __esModule: true,
+  default: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(() => ({
+    sendMail,
+    use,
+  })),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+}));
+
+function makeJsonRequest(body: unknown) {
+  return new NextRequest('http://localhost/api/form', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/form', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      RECAPTCHA_SECRET_KEY: 'test-secret',
+      SMTP_PORT: '465',
+      SMTP_HOST: 'smtp.test',
+      SMTP_USER: 'user',
+      SMTP_PASSWORD: 'pass',
+      CONTACT_FORM_SEND_EMAIL_DOMAIN: 'example.com',
+      CONTACT_FORM_RECEIVE_EMAIL: 'inbox@example.com',
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ success: true }),
+    }) as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = new NextRequest('http://localhost/api/form', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json{',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      errors: ['Invalid request body'],
+    });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when reCAPTCHA validation fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: async () => ({ success: false }),
+    });
+
+    const res = await POST(
+      makeJsonRequest({
+        name: 'A',
+        email: 'a@b.c',
+        phone: '1',
+        message: '1234567890',
+        token: 'bad',
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      errors: ["It's a bot! ❤️ ❌ 🤖"],
+    });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it('calls sendMail with form context when human verification succeeds', async () => {
+    const payload = {
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      phone: '+49 1',
+      message: 'Hello world!',
+      token: 'good-token',
+    };
+
+    const res = await POST(makeJsonRequest(payload));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ message: 'success' });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'https://www.google.com/recaptcha/api/siteverify?secret=test-secret&response=good-token',
+      ),
+      { method: 'POST' },
+    );
+
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'Jane Doe no-reply@example.com',
+        replyTo: 'jane@example.com',
+        to: 'inbox@example.com',
+        subject: 'Neue Anfrage, Dücker Medizintechnik Kontaktformular',
+        template: 'contact',
+        context: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          phone: '+49 1',
+          message: 'Hello world!',
+        },
+      }),
+    );
+  });
+
+  it('returns 500 when sendMail throws', async () => {
+    sendMail.mockRejectedValueOnce(new Error('SMTP down'));
+
+    const res = await POST(
+      makeJsonRequest({
+        name: 'X',
+        email: 'x@y.z',
+        phone: '1',
+        message: '1234567890',
+        token: 'tok',
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ message: 'an error occurred' });
+  });
+});

--- a/src/components/__tests__/ContactForm.test.tsx
+++ b/src/components/__tests__/ContactForm.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { act } from 'react';
 
 import createIntlWrapper from '@/lib/i18n-testing';
@@ -26,13 +26,6 @@ jest.mock('react-google-recaptcha', () => {
   });
 });
 
-jest.mock('nodemailer', () => ({
-  createTransport: jest.fn().mockReturnValue({
-    sendMail: jest.fn().mockResolvedValue(true),
-    use: jest.fn(),
-  }),
-}));
-
 global.fetch = jest.fn(
   (): Promise<any> =>
     Promise.resolve({
@@ -48,7 +41,13 @@ describe('ContactForm', () => {
 
   beforeEach(async () => {
     wrapper = await createIntlWrapper(['common', 'contact']);
-    (global.fetch as jest.Mock).mockClear();
+    (global.fetch as jest.Mock).mockReset();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve({ message: 'success' }),
+    });
   });
 
   it('should render correctly', () => {
@@ -63,11 +62,56 @@ describe('ContactForm', () => {
   });
 
   it('should submit the form correctly', async () => {
+    const { getByLabelText, getByRole } = render(<ContactForm />, { wrapper });
+
+    await act(async () => {
+      fireEvent.input(getByLabelText(/Ihr Vor- & Nachname/i), {
+        target: { value: 'John Doe' },
+      });
+      fireEvent.input(getByLabelText(/Ihre E-Mail/i), {
+        target: { value: 'johndoe@example.com' },
+      });
+      fireEvent.input(getByLabelText(/Ihre Telefonnummer/i), {
+        target: { value: '0123456789' },
+      });
+      fireEvent.input(getByLabelText(/Ihre Nachricht/i), {
+        target: { value: 'Test Test Test Test' },
+      });
+      fireEvent.click(getByLabelText(/Ich habe die/i));
+      fireEvent.click(getByRole('button', { name: /Absenden/i }));
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/form',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      name: 'John Doe',
+      email: 'johndoe@example.com',
+      phone: '0123456789',
+      message: 'Test Test Test Test',
+      terms: true,
+      token: 'mocked_token',
+    });
+
+    expect(
+      await screen.findByText(/Vielen Dank für Ihre Nachricht/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows API error message when response is not ok', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: () => Promise.resolve({ message: 'success' }),
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({ errors: ['Validation failed', 'Missing field'] }),
     });
 
     const { getByLabelText, getByRole } = render(<ContactForm />, { wrapper });
@@ -88,5 +132,80 @@ describe('ContactForm', () => {
       fireEvent.click(getByLabelText(/Ich habe die/i));
       fireEvent.click(getByRole('button', { name: /Absenden/i }));
     });
+
+    expect(
+      await screen.findByText(/Validation failed, Missing field/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows generic API error when response is not ok without detail', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+
+    const { getByLabelText, getByRole } = render(<ContactForm />, { wrapper });
+
+    await act(async () => {
+      fireEvent.input(getByLabelText(/Ihr Vor- & Nachname/i), {
+        target: { value: 'John Doe' },
+      });
+      fireEvent.input(getByLabelText(/Ihre E-Mail/i), {
+        target: { value: 'johndoe@example.com' },
+      });
+      fireEvent.input(getByLabelText(/Ihre Telefonnummer/i), {
+        target: { value: '0123456789' },
+      });
+      fireEvent.input(getByLabelText(/Ihre Nachricht/i), {
+        target: { value: 'Test Test Test Test' },
+      });
+      fireEvent.click(getByLabelText(/Ich habe die/i));
+      fireEvent.click(getByRole('button', { name: /Absenden/i }));
+    });
+
+    expect(
+      await screen.findByText(/Die Nachricht konnte nicht gesendet werden\.$/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows network error when fetch throws', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('offline'));
+
+    const { getByLabelText, getByRole } = render(<ContactForm />, { wrapper });
+
+    await act(async () => {
+      fireEvent.input(getByLabelText(/Ihr Vor- & Nachname/i), {
+        target: { value: 'John Doe' },
+      });
+      fireEvent.input(getByLabelText(/Ihre E-Mail/i), {
+        target: { value: 'johndoe@example.com' },
+      });
+      fireEvent.input(getByLabelText(/Ihre Telefonnummer/i), {
+        target: { value: '0123456789' },
+      });
+      fireEvent.input(getByLabelText(/Ihre Nachricht/i), {
+        target: { value: 'Test Test Test Test' },
+      });
+      fireEvent.click(getByLabelText(/Ich habe die/i));
+      fireEvent.click(getByRole('button', { name: /Absenden/i }));
+    });
+
+    expect(
+      await screen.findByText(/Netzwerkfehler beim Senden/i),
+    ).toBeInTheDocument();
+  });
+
+  it('validates required fields on submit', async () => {
+    const { getByRole } = render(<ContactForm />, { wrapper });
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: /Absenden/i }));
+    });
+
+    expect(
+      await screen.findByText(/Bitte geben Sie Ihren Vor- und Nachnamen ein/i),
+    ).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/components/__tests__/CookieConsentConditional.test.tsx
+++ b/src/components/__tests__/CookieConsentConditional.test.tsx
@@ -1,0 +1,243 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+jest.mock('cobe', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('next/script', () => ({
+  __esModule: true,
+  default: function MockScript({
+    id,
+    src,
+    dangerouslySetInnerHTML,
+    ...rest
+  }: {
+    id?: string;
+    src?: string;
+    dangerouslySetInnerHTML?: { __html: string };
+    [key: string]: unknown;
+  }) {
+    if (src) {
+      /* eslint-disable-next-line @next/next/no-sync-scripts -- test double for next/script */
+      return <script id={id} src={src} {...rest} />;
+    }
+    return (
+      /* eslint-disable-next-line @next/next/no-sync-scripts -- test double for next/script */
+      <script
+        id={id}
+        dangerouslySetInnerHTML={dangerouslySetInnerHTML}
+        {...rest}
+      />
+    );
+  },
+}));
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/de/kontakt',
+}));
+
+const consentFlags = {
+  measurement: false,
+  marketing: false,
+};
+
+const mockHas = jest.fn((category: string) => {
+  if (category === 'measurement') return consentFlags.measurement;
+  if (category === 'marketing') return consentFlags.marketing;
+  return false;
+});
+
+const mockSetSelectedConsent = jest.fn();
+const mockSaveConsents = jest.fn();
+const mockSetActiveUI = jest.fn();
+
+jest.mock('@c15t/nextjs', () => ({
+  useConsentManager: () => ({
+    has: mockHas,
+    setSelectedConsent: mockSetSelectedConsent,
+    saveConsents: mockSaveConsents,
+    setActiveUI: mockSetActiveUI,
+    consents: { necessary: true, measurement: false, marketing: false },
+    getDisplayedConsents: () => [
+      { name: 'necessary', disabled: true },
+      { name: 'measurement', disabled: false },
+      { name: 'marketing', disabled: false },
+    ],
+    selectedConsents: {},
+  }),
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { act } from 'react';
+
+import createIntlWrapper from '@/lib/i18n-testing';
+
+import GoogleAnalytics from '@/components/helpers/GoogleAnalytics';
+import Hotjar from '@/components/helpers/Hotjar';
+import { ContactMap } from '@/components/templates/ContactMap';
+import ContactView from '@/components/templates/ContactView';
+
+describe('Cookie / consent conditional renders', () => {
+  beforeEach(() => {
+    consentFlags.measurement = false;
+    consentFlags.marketing = false;
+    jest.clearAllMocks();
+    document.querySelectorAll('script').forEach((el) => el.remove());
+  });
+
+  describe('GoogleAnalytics', () => {
+    it('renders nothing without measurement consent', () => {
+      consentFlags.measurement = false;
+      const { container } = render(
+        <GoogleAnalytics GA_MEASUREMENT_ID='GA_X' />,
+      );
+      expect(container.querySelectorAll('script')).toHaveLength(0);
+    });
+
+    it('renders nothing when GA_MEASUREMENT_ID is missing', () => {
+      consentFlags.measurement = true;
+      const { container } = render(
+        <GoogleAnalytics GA_MEASUREMENT_ID={undefined} />,
+      );
+      expect(container.querySelectorAll('script')).toHaveLength(0);
+    });
+
+    it('renders gtag scripts when id is set and measurement consent is granted', () => {
+      consentFlags.measurement = true;
+      render(<GoogleAnalytics GA_MEASUREMENT_ID='GA_TEST' />);
+      const scripts = document.querySelectorAll('script');
+      expect(scripts.length).toBeGreaterThanOrEqual(2);
+      expect(scripts[0].getAttribute('src')).toContain('googletagmanager.com');
+      expect(scripts[0].getAttribute('src')).toContain('GA_TEST');
+    });
+  });
+
+  describe('Hotjar', () => {
+    it('renders nothing without measurement consent', () => {
+      consentFlags.measurement = false;
+      const { container } = render(<Hotjar HOTJAR_ID='HJ_1' />);
+      expect(container.querySelector('#hotjar')).toBeNull();
+    });
+
+    it('renders nothing when HOTJAR_ID is missing', () => {
+      consentFlags.measurement = true;
+      const { container } = render(<Hotjar HOTJAR_ID={undefined} />);
+      expect(container.querySelector('#hotjar')).toBeNull();
+    });
+
+    it('renders Hotjar snippet when id is set and measurement consent is granted', () => {
+      consentFlags.measurement = true;
+      render(<Hotjar HOTJAR_ID='HJ_TEST' />);
+      const el = document.getElementById('hotjar');
+      expect(el).not.toBeNull();
+      expect(el?.innerHTML).toContain('HJ_TEST');
+    });
+
+    it('removes Hotjar script when measurement consent is withdrawn after mount', async () => {
+      consentFlags.measurement = true;
+      const { rerender } = render(<Hotjar HOTJAR_ID='HJ_OPT' />);
+      expect(document.getElementById('hotjar')).not.toBeNull();
+
+      consentFlags.measurement = false;
+      await act(async () => {
+        rerender(<Hotjar HOTJAR_ID='HJ_OPT' />);
+      });
+
+      await waitFor(() => {
+        expect(document.getElementById('hotjar')).toBeNull();
+      });
+    });
+  });
+
+  describe('ContactView (marketing-gated contact form)', () => {
+    let wrapper: React.ComponentType<{ children: React.ReactNode }>;
+
+    beforeEach(async () => {
+      wrapper = await createIntlWrapper(['common', 'contact']);
+    });
+
+    it('shows reCAPTCHA cookie notice when marketing consent is off', async () => {
+      consentFlags.marketing = false;
+      render(<ContactView />, { wrapper });
+
+      expect(
+        await screen.findByText(/Marketing-Cookies aktiviert sind/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText(/Ihr Vor- & Nachname/i)).toBeNull();
+    });
+
+    it('renders ContactForm when marketing consent is granted', async () => {
+      consentFlags.marketing = true;
+      render(<ContactView />, { wrapper });
+
+      expect(
+        await screen.findByLabelText(/Ihr Vor- & Nachname/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('ContactMap (marketing-gated iframe)', () => {
+    let wrapper: React.ComponentType<{ children: React.ReactNode }>;
+
+    beforeEach(async () => {
+      wrapper = await createIntlWrapper(['common', 'contact']);
+    });
+
+    it('shows cookie banner when marketing consent is off', async () => {
+      consentFlags.marketing = false;
+      render(<ContactMap />, { wrapper });
+
+      expect(
+        await screen.findByText(/Google Maps geladen/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Marketing-Cookies akzeptieren/i }),
+      ).toBeInTheDocument();
+      expect(screen.queryByTitle(/Google Maps/i)).toBeNull();
+    });
+
+    it('embeds Google Maps iframe when marketing consent is granted', async () => {
+      consentFlags.marketing = true;
+      render(<ContactMap />, { wrapper });
+
+      const iframe = await screen.findByTitle(/Google Maps/i);
+      expect(iframe).toBeInTheDocument();
+      expect(iframe.getAttribute('src')).toContain('maps.google');
+    });
+
+    it('accept button saves custom consent with marketing enabled', async () => {
+      consentFlags.marketing = false;
+      render(<ContactMap />, { wrapper });
+
+      await screen.findByText(/Google Maps geladen/i);
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole('button', {
+            name: /Marketing-Cookies akzeptieren/i,
+          }),
+        );
+      });
+
+      expect(mockSetSelectedConsent).toHaveBeenCalledWith('measurement', false);
+      expect(mockSetSelectedConsent).toHaveBeenCalledWith('marketing', true);
+      expect(mockSaveConsents).toHaveBeenCalledWith('custom');
+    });
+
+    it('cookie settings opens consent dialog', async () => {
+      consentFlags.marketing = false;
+      render(<ContactMap />, { wrapper });
+
+      await screen.findByText(/Google Maps geladen/i);
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole('button', { name: /Cookie-Einstellungen/i }),
+        );
+      });
+
+      expect(mockSetActiveUI).toHaveBeenCalledWith('dialog');
+    });
+  });
+});

--- a/src/components/templates/Breadcrumbs.tsx
+++ b/src/components/templates/Breadcrumbs.tsx
@@ -15,7 +15,7 @@ export default function Breadcrumbs({ className }: { className?: string }) {
   const t = useTranslations('common');
 
   // Strip locale prefix to get meaningful path segments
-  const segments = pathname.split('/').filter(Boolean);
+  const segments = (pathname ?? '').split('/').filter(Boolean);
   const hasLocale = i18nConfig.locales.some((l) => l === segments[0]);
   const locale = hasLocale ? segments[0] : i18nConfig.defaultLocale;
   const pathSegments = hasLocale ? segments.slice(1) : segments;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds automated coverage for the contact form end-to-end behavior, the `/api/form` handler with mocked mail delivery, and the main consent-dependent UI paths (measurement vs marketing).

## What changed

- **API route tests** (`src/app/api/form/__tests__/route.test.ts`): invalid JSON, failed reCAPTCHA, successful `sendMail` payload assertions, and SMTP error handling with Sentry mocked.
- **Contact form tests** (`src/components/__tests__/ContactForm.test.tsx`): success path with fetch body + token, API error with detail, generic error, network failure, and client-side validation (removed unused nodemailer mock from the client test file).
- **Cookie / consent UI** (`src/components/__tests__/CookieConsentConditional.test.tsx`): Google Analytics and Hotjar branches with toggled `measurement` consent; `ContactView` and `ContactMap` branches with toggled `marketing` consent; map banner actions call the consent manager as expected. Mocks include `cobe`, `next/script`, and a stable `usePathname` for breadcrumbs.
- **Breadcrumbs** (`src/components/templates/Breadcrumbs.tsx`): guard `usePathname()` when it is `null` so tests and edge environments do not crash.

## Verification

- `pnpm test` (all suites)
- ESLint on touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5838ead-5f78-48ce-826d-a21b5a5220d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5838ead-5f78-48ce-826d-a21b5a5220d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

