### PR TITLE
fix(i18n): respect German as default locale in redirects (#353)

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -3,4 +3,6 @@ import { defineRouting } from 'next-intl/routing';
 export const routing = defineRouting({
   locales: ['de', 'en'],
   defaultLocale: 'de',
+  // Rely on URL (and defaultLocale for unprefixed paths), not Accept-Language / cookie
+  localeDetection: false,
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes incorrect redirects to `/en/` when the configured default locale is German (`de`).

## Cause
[next-intl middleware](https://next-intl.dev/docs/routing/middleware#locale-detection) chooses a locale using the URL prefix, then `NEXT_LOCALE` cookie, then the `Accept-Language` header, and only then `defaultLocale`. Browsers that prefer English were therefore sent to `/en/` even though the site default is `de`.

## Change
Set `localeDetection: false` in `defineRouting` so the locale is determined from the URL (and `defaultLocale` for paths without a prefix), not from `Accept-Language` or a prior cookie.

Closes #353
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaf84e22-6154-44c2-b21f-b2b97c3e7bd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaf84e22-6154-44c2-b21f-b2b97c3e7bd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated language detection to prioritize URL path for locale selection instead of relying on browser preferences and cookies, ensuring consistent behavior across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->