### PR TITLE
fix(images): allow /public /images paths in Next.js localPatterns

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,6 @@ const nextConfig = {
       { pathname: '/api/cms/assets/**/' },
       // Static files under /public (e.g. /images/...) when using <Image src="/images/...">
       { pathname: '/images/**' },
-      { pathname: '/images/**/' },
     ],
     remotePatterns: [
       // Directus media host – derived from NEXT_PUBLIC_DIRECTUS_URL so we

--- a/next.config.js
+++ b/next.config.js
@@ -47,10 +47,6 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: 'cms.duecker-medizintechnik.de',
-      },
-      {
-        protocol: 'https',
         hostname: 'picsum.photos',
       },
     ],

--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,9 @@ const nextConfig = {
     localPatterns: [
       { pathname: '/api/cms/assets/**' },
       { pathname: '/api/cms/assets/**/' },
+      // Static files under /public (e.g. /images/...) when using <Image src="/images/...">
+      { pathname: '/images/**' },
+      { pathname: '/images/**/' },
     ],
     remotePatterns: [
       // Directus media host – derived from NEXT_PUBLIC_DIRECTUS_URL so we

--- a/src/components/templates/StickyScroll/StickyScroll.tsx
+++ b/src/components/templates/StickyScroll/StickyScroll.tsx
@@ -145,7 +145,7 @@ export const StickyScroll = () => {
                     className='object-cover object-center transition-transform duration-500 group-hover:scale-[1.03]'
                     placeholder='blur'
                     priority={index === 0}
-                    sizes='100vw'
+                    sizes='(max-width: 767px) calc(100vw - 2rem), calc(100vw - 4rem)'
                   />
                   <div className='absolute inset-0 bg-gradient-to-t from-black/75 via-black/20 to-transparent' />
                   <div className='absolute inset-x-0 bottom-0 p-5'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

1. **localPatterns / production 400** – allow `/images/**` for public static assets when using string paths with `next/image` (e.g. production page grid image).

2. **StickyScroll mobile** – the stacked cards live inside `Container` (horizontal `px-4` / `md:px-8`), so the image is not full viewport width. Replaced `sizes="100vw"` with values that account for that padding: `(max-width: 767px) calc(100vw - 2rem), calc(100vw - 4rem)`.

3. **remotePatterns** – removed duplicate `cms.duecker-medizintechnik.de` entry. The Directus host from `NEXT_PUBLIC_DIRECTUS_URL` already provides the same hostname when that env is set; `admin.duecker-medizintechnik.de` stays for cases that need a separate allowlist.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2253814f-6cb2-440c-846a-c8adbe7f3d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2253814f-6cb2-440c-846a-c8adbe7f3d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

