### PR TITLE
Parallax-Effekt für Hero-Image-Bars (Produktion, Downloads, etc.)

### DIFF
--- a/src/components/layout/Page.tsx
+++ b/src/components/layout/Page.tsx
@@ -39,11 +39,14 @@ export default function Page({
   title,
 }: PageProps) {
   const flags = useFlags(['image_banner']);
+  const imageBannerOn = flags.image_banner.enabled;
+  const overlapHero = Boolean(image && layout.showHero && imageBannerOn);
+
   return (
     <Layout>
       {image &&
         layout.showHero &&
-        (flags.image_banner.enabled ? (
+        (imageBannerOn ? (
           <ImageBanner
             alt={title}
             className='flex-1'
@@ -57,6 +60,7 @@ export default function Page({
       {layout.topContent}
       <main
         className={clsxm(
+          overlapHero && '-mt-12 relative z-10 rounded-t-2xl md:-mt-16',
           layout.background === 'light' && 'bg-white',
           layout.background === 'dark' && 'bg-black',
           layout.background === 'primary' && 'bg-primary-500',

--- a/src/components/templates/ImageBanner/ImageBanner.tsx
+++ b/src/components/templates/ImageBanner/ImageBanner.tsx
@@ -1,6 +1,12 @@
 import clsx from 'clsx';
-import { motion } from 'framer-motion';
+import {
+  motion,
+  useReducedMotion,
+  useScroll,
+  useTransform,
+} from 'framer-motion';
 import Image, { StaticImageData } from 'next/image';
+import { useRef } from 'react';
 
 import {
   ImageBannerRole,
@@ -21,6 +27,9 @@ type Props = {
   staticAnimation?: boolean;
 };
 
+const imageParallaxY = '14%';
+const imageParallaxScale = 1.1;
+
 const ImageBanner = ({
   alt,
   className,
@@ -30,27 +39,53 @@ const ImageBanner = ({
   src,
   staticAnimation,
 }: Props) => {
+  const figureRef = useRef<HTMLFigureElement | null>(null);
+  const shouldReduce = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: figureRef,
+    offset: ['start end', 'end start'],
+  });
+  const parallaxY = useTransform(
+    scrollYProgress,
+    [0, 1],
+    [imageParallaxY, `-${imageParallaxY}`],
+  );
+
   return (
     <motion.figure
+      ref={figureRef}
       whileInView={VariantNames.Animate}
       viewport={{ once: true, amount: 0.4 }}
       initial={VariantNames.Initial}
       custom={delay}
       variants={staticAnimation ? {} : imgBannerVariants}
       className={clsx(
-        'relative min-h-[250px] w-full self-end overflow-hidden md:min-h-[350px]',
+        'relative z-0 min-h-[250px] w-full self-end overflow-hidden md:min-h-[350px]',
         className,
       )}
     >
-      <Image
-        src={src}
-        sizes={responsiveImageSizes[role]}
-        fill
-        quality={90}
-        priority={priority}
-        alt={alt}
-        className='object-cover'
-      />
+      <motion.div
+        aria-hidden
+        className='absolute inset-0 -top-[5%] -bottom-[5%]'
+        style={
+          shouldReduce
+            ? undefined
+            : {
+                y: parallaxY,
+                scale: imageParallaxScale,
+              }
+        }
+      >
+        <Image
+          src={src}
+          sizes={responsiveImageSizes[role]}
+          fill
+          quality={90}
+          priority={priority}
+          alt={alt}
+          className='object-cover'
+        />
+      </motion.div>
     </motion.figure>
   );
 };

--- a/src/components/templates/ProduktionLeistungenView.tsx
+++ b/src/components/templates/ProduktionLeistungenView.tsx
@@ -16,7 +16,7 @@ export function ProduktionLeistungenView({ title }: { title: string }) {
       layout={{
         background: 'light',
         showBreadcrumbs: true,
-        showHero: false,
+        showHero: true,
         padding: 'small',
       }}
       image={SERVICES_PAGE_HERO['/leistungen/produktion'].image}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Änderungen

- **ImageBanner:** Scroll-Parallax für das Hintergrundbild (Bild bewegt sich vertikal über die Viewport-Scroll-Progress). Bei `prefers-reduced-motion` bleibt das Verhalten statisch. Leichtes **Scale (1,1)**, damit bei der Translation keine leeren Ränder sichtbar werden.
- **Page:** Wenn der Hero-Banner (Feature-Flag `image_banner`) aktiv ist, bekommt `<main>` einen leichten **negativen oberen Rand** und abgerundete obere Ecken, sodass der **weiße Inhaltsblock optisch „aufs“ Bild rutscht** statt hart daran anzuliegen.
- **Produktions-Seite:** `showHero: true`, damit derselbe Hero-Balken wie bei Downloads und Reparatur erscheint (vorher war das Bild in den Props, wurde aber wegen `showHero: false` nicht gerendert).

## Technik

- Framer Motion: `useScroll` / `useTransform` am `<figure>`, `offset: ['start end', 'end start']`.

## Hinweis

Der Hero erscheint nur, wenn das **Flagsmith**-Feature `image_banner` für die Umgebung aktiviert ist.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0aa4f84-e960-4405-abff-31983d91ecda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0aa4f84-e960-4405-abff-31983d91ecda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

