### PR TITLE
Render Directus post content as HTML or Markdown (sanitized)

### DIFF
--- a/src/components/templates/NewsArticle.tsx
+++ b/src/components/templates/NewsArticle.tsx
@@ -4,7 +4,7 @@ import { useFlags } from 'flagsmith/react';
 import { marked } from 'marked';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   RiFacebookCircleFill,
   RiMailFill,
@@ -31,6 +31,48 @@ import { News } from '@/types/News';
 type NewsArticleProps = {
   post: News;
 };
+
+function looksLikeHtml(input: string): boolean {
+  // Heuristic: treat as HTML if it contains at least one tag.
+  // This avoids running HTML through `marked()` (which is intended for Markdown).
+  return /<\/?[a-z][\s\S]*>/i.test(input);
+}
+
+function sanitizeHtmlUnsafeButBetterThanNothing(html: string): string {
+  // We can't rely on external deps in all runtimes here, so keep a conservative,
+  // dependency-free sanitizer. This is primarily to strip obvious XSS vectors.
+  //
+  // If you later add user-generated content, replace this with DOMPurify (or
+  // sanitize-html) in a server/client compatible way.
+  let out = html;
+
+  // Remove dangerous elements entirely.
+  out = out.replace(
+    /<(script|style|iframe|object|embed|link|meta)\b[\s\S]*?>[\s\S]*?<\/\1\s*>/gi,
+    '',
+  );
+  out = out.replace(/<(script|style|iframe|object|embed|link|meta)\b[\s\S]*?>/gi, '');
+
+  // Remove inline event handlers and a few high-risk attributes.
+  out = out.replace(/\son\w+\s*=\s*(".*?"|'.*?'|[^\s>]+)/gi, '');
+  out = out.replace(/\s(srcdoc)\s*=\s*(".*?"|'.*?'|[^\s>]+)/gi, '');
+
+  // Neutralize javascript: URLs in href/src.
+  out = out.replace(
+    /\s(href|src)\s*=\s*(["'])\s*javascript:[\s\S]*?\2/gi,
+    ' $1=$2#$2',
+  );
+
+  return out;
+}
+
+function renderPostContent(content: string): string {
+  const raw = content ?? '';
+  if (!raw) return '';
+
+  const html = looksLikeHtml(raw) ? raw : (marked(raw) as string);
+  return sanitizeHtmlUnsafeButBetterThanNothing(html);
+}
 
 const ArticleMeta = ({ post }: { post: News }) => (
   <div className='flex flex-row items-center gap-x-4'>
@@ -211,20 +253,23 @@ const ArticleImage = ({ post }: { post: News }) => {
 };
 
 const ArticleContent = ({ post }: { post: News }) => (
-  <div
-    className='news__content mx-auto w-full max-w-3xl'
-    data-directus={setVisualEditorAttr({
-      collection: 'posts',
-      item: post.id,
-      fields: 'content',
-      mode: 'modal',
-    })}
-    // Content is sourced from a controlled Directus CMS – not user-facing input.
-    // If user-generated content is added in future, sanitize with DOMPurify.
-    dangerouslySetInnerHTML={{
-      __html: marked(post.content ?? '') as string,
-    }}
-  />
+  // `post.content` comes from Directus and may be either Markdown (legacy) or
+  // WYSIWYG HTML. We render both, but avoid passing HTML through `marked()`.
+  (() => {
+    const html = useMemo(() => renderPostContent(post.content ?? ''), [post.content]);
+    return (
+      <div
+        className='news__content mx-auto w-full max-w-3xl'
+        data-directus={setVisualEditorAttr({
+          collection: 'posts',
+          item: post.id,
+          fields: 'content',
+          mode: 'modal',
+        })}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  })()
 );
 
 const ArticleAuthor = ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description & Technical Solution

Directus `posts.content` can be either WYSIWYG HTML or Markdown. The current `NewsArticle` always runs `marked()` and renders the result as HTML, which is semantically incorrect for already-HTML content and also means we were not doing any sanitizing.

This change adds a small rendering wrapper in `src/components/templates/NewsArticle.tsx`:

- Detects whether `post.content` looks like HTML
- If HTML: renders it directly
- If not HTML: converts Markdown to HTML via `marked()`
- Sanitizes the resulting HTML with a conservative dependency-free sanitizer (strips common XSS vectors like `<script>` and inline `on*=` handlers)

This addresses the “HTML coming from the editor” mismatch and improves safety without changing the Directus integration/data flow.

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] Already rebased against main branch.

# Screenshots

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de30088f-9a59-4551-833b-a471116fb43c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de30088f-9a59-4551-833b-a471116fb43c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

