### PR TITLE
docs: clarify Directus CSP for Visual Editor / Live Preview iframe

### DIFF
--- a/docs/directus-setup.md
+++ b/docs/directus-setup.md
@@ -24,7 +24,13 @@ Directus anlegen musst, damit das Frontend ohne Anpassungen funktioniert.
 
 - **Live Preview & Visual Editor** laden deine Frontend-URLs in einem
   `<iframe>`. Diese Ursprünge müssen in der **Directus**-CSP unter **`frame-src`**
-  stehen (Umgebungsvariablen, nicht im Next.js-Projekt).
+  stehen (Umgebungsvariablen auf dem **Directus-Server**, nicht im Next.js-Projekt).
+
+  Wenn **`frame-src` nicht gesetzt** ist, verwenden Browser **`child-src` als
+  Fallback**. Directus setzt standardmäßig z. B. `child-src 'self' blob:` –
+  dann erscheint in der Konsole genau der Fehler: *Framing 'https://…' violates
+  … child-src 'self' blob:*. Abhilfe: **`frame-src`** wie unten setzen und
+  Directus neu starten.
 
   Produktion + lokale Entwicklung:
 
@@ -206,6 +212,32 @@ Häufigste Ursachen, in der Reihenfolge wie sie geprüft werden sollten:
 4. **CORS.** Wenn Directus selbst gehostet wird, müssen `CORS_ENABLED=true`
    und `CORS_ORIGIN` so gesetzt sein, dass die Frontend-Domain zugelassen
    ist.
+
+### Live Preview / Visual Editor: CSP blockiert das iframe
+
+**Symptom:** In der Browser-Konsole (im Directus-Admin, nicht auf der
+öffentlichen Site) Meldungen wie:
+
+- *Framing 'https://duecker-medizintechnik.de/…' violates … **child-src**
+  'self' blob:* … **frame-src** was not explicitly set, so **child-src** is used
+  as a fallback.*
+
+**Ursache:** Die Preview-URL / Visual-Editor-URL zeigt auf eure
+Next.js-Domain, aber die **CSP des Directus-Backends** erlaubt dieses Origin im
+iframe noch nicht.
+
+**Lösung:** Auf dem Directus-Host
+`CONTENT_SECURITY_POLICY_DIRECTIVES__FRAME_SRC` setzen (siehe Abschnitt 1),
+Directus **neu starten**, dann Preview / Visual Editor erneut öffnen.
+
+**Hinweis zu *chrome-error://chromewebdata***: Wenn das iframe wegen CSP
+blockiert wird, kann Chrome eine Fehlerseite im Frame laden; Meldungen über
+*Domains, protocols and ports must match* sind dann Folge des blockierten
+Loads, nicht zwingend ein separates Problem auf der Website.
+
+**Hinweis zu *message channel closed* / Extension-Errors:** Oft stammen
+asynchrone Listener-Fehler von **Browser-Extensions** oder vom abgebrochenen
+iframe; zuerst CSP beheben und testweise ohne Extensions prüfen.
 
 ### Server-Logs
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Operators saw browser console errors when using Directus Live Preview and Visual Editor: framing `https://duecker-medizintechnik.de/` was blocked because `frame-src` was not set on the Directus host, so the browser fell back to restrictive `child-src 'self' blob:`.

## Changes

- In `docs/directus-setup.md`, explain the `child-src` fallback when `frame-src` is missing.
- Add a troubleshooting subsection for this CSP symptom, plus brief notes on `chrome-error://chromewebdata` and extension-related message channel errors.

## Deployment note

The fix for production remains configuring Directus (e.g. `CONTENT_SECURITY_POLICY_DIRECTIVES__FRAME_SRC` as documented) and restarting the Directus process; this PR only improves documentation for that workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8472dfc4-e949-4179-8ca1-484d95d1d12c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8472dfc4-e949-4179-8ca1-484d95d1d12c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

