### PR TITLE
fix(draft): use public origin for draft redirects behind proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 ##################################
 # ********* App Config ********* #
 ##################################
-# App Configuration (canonical origin for Open Graph URLs)
+# App Configuration (canonical origin for Open Graph URLs and /api/draft redirects behind a proxy)
 NEXT_PUBLIC_APP_URL=""
 NEXT_PUBLIC_SHOW_LOGGER=""
 # Directus Configuration

--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ The site reads its content from a Directus instance (e.g. `https://admin.duecker
 
 ```
 NEXT_PUBLIC_DIRECTUS_URL=https://admin.duecker-medizintechnik.de
+NEXT_PUBLIC_APP_URL=https://duecker-medizintechnik.de
 DIRECTUS_API_TOKEN=<static-token-of-a-read-only-service-user>
 DIRECTUS_PREVIEW_SECRET=<long-random-string-shared-with-directus>
 ```
+
+`NEXT_PUBLIC_APP_URL` should be the public site origin (no trailing slash). It keeps `/api/draft` redirects correct behind Coolify or other reverse proxies.
 
 See [`docs/directus-setup.md`](./docs/directus-setup.md) for the collections,
 fields and Live Preview / Visual Editor setup that the frontend expects.

--- a/docs/directus-setup.md
+++ b/docs/directus-setup.md
@@ -146,6 +146,12 @@ Auf der Frontend-Seite öffnet `app/api/draft/route.ts` daraufhin den
 Draft-Mode (`draftMode().enable()`) und leitet auf die normale
 Newsroom-Detailseite weiter, die das Item mit Status `draft` ausliefert.
 
+**Hinter Reverse-Proxys (Coolify):** Setzt **`NEXT_PUBLIC_APP_URL`** auf die
+öffentliche Origin (z. B. `https://duecker-medizintechnik.de`), damit der
+Redirect nach `/api/draft` nicht versehentlich auf die **interne** Host-URL
+(z. B. `https://localhost:3000`) zeigt. Fehlt die Variable, nutzt die Route
+`X-Forwarded-Host` / `X-Forwarded-Proto`, sofern der Proxy sie setzt.
+
 Ausstieg aus Draft Mode (z.B. für Tester):
 `https://duecker-medizintechnik.de/api/draft/disable?redirect=/de/newsroom`.
 
@@ -206,6 +212,22 @@ Häufigste Ursachen, in der Reihenfolge wie sie geprüft werden sollten:
 4. **CORS.** Wenn Directus selbst gehostet wird, müssen `CORS_ENABLED=true`
    und `CORS_ORIGIN` so gesetzt sein, dass die Frontend-Domain zugelassen
    ist.
+
+### Live Preview landet auf `https://localhost:3000`
+
+**Symptom:** Preview-iframe oder manueller Aufruf von
+`/api/draft?secret=…&type=posts&id=…` leitet auf **`https://localhost:3000/…`**
+weiter, obwohl die Preview-URL mit der Produktionsdomain beginnt.
+
+**Ursache:** Der Redirect in `app/api/draft/route.ts` baut die Ziel-URL aus der
+Request-Origin. Steht Next hinter einem Proxy, kann `request.url` die **interne**
+Origin sein (Coolify → Container auf `localhost:3000`).
+
+**Lösung:** **`NEXT_PUBLIC_APP_URL`** auf die öffentliche Site setzen (siehe
+Abschnitt 4), oder sicherstellen, dass der Proxy **`X-Forwarded-Host`** /
+**`X-Forwarded-Proto`** an Next durchreicht. Seit dem Fix in diesem Repo wird
+die öffentliche Origin bevorzugt; ein gesetztes `NEXT_PUBLIC_APP_URL` bleibt die
+zuverlässigste Variante.
 
 ### Server-Logs
 

--- a/src/app/api/draft/disable/route.ts
+++ b/src/app/api/draft/disable/route.ts
@@ -1,6 +1,8 @@
 import { draftMode } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
+import { getRedirectOriginFromRequest } from '@/lib/get-base-url';
+
 /**
  * Exits Draft Mode. Call this with a `?redirect=/some/path` query parameter
  * to be redirected back to a normal (cached) page render.
@@ -12,5 +14,6 @@ export async function GET(request: NextRequest) {
   const draft = await draftMode();
   draft.disable();
 
-  return NextResponse.redirect(new URL(redirect, request.url));
+  const origin = getRedirectOriginFromRequest(request);
+  return NextResponse.redirect(new URL(redirect, origin));
 }

--- a/src/app/api/draft/route.ts
+++ b/src/app/api/draft/route.ts
@@ -1,6 +1,7 @@
 import { draftMode } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
+import { getRedirectOriginFromRequest } from '@/lib/get-base-url';
 import { getPostById } from '@/lib/posts';
 
 import { directusPreviewSecret } from '@/constant/env';
@@ -53,5 +54,6 @@ export async function GET(request: NextRequest) {
   const draft = await draftMode();
   draft.enable();
 
-  return NextResponse.redirect(new URL(target, request.url));
+  const origin = getRedirectOriginFromRequest(request);
+  return NextResponse.redirect(new URL(target, origin));
 }

--- a/src/lib/__tests__/get-redirect-origin-from-request.test.ts
+++ b/src/lib/__tests__/get-redirect-origin-from-request.test.ts
@@ -1,0 +1,74 @@
+import type { NextRequest } from 'next/server';
+
+import { getRedirectOriginFromRequest } from '@/lib/get-base-url';
+
+const originalEnv = { ...process.env };
+
+function mockRequest(headers: Record<string, string>): NextRequest {
+  return {
+    headers: {
+      get(name: string) {
+        const v = headers[name.toLowerCase()];
+        return v === undefined ? null : v;
+      },
+    },
+  } as NextRequest;
+}
+
+describe('getRedirectOriginFromRequest', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key as keyof NodeJS.ProcessEnv];
+      }
+    }
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('uses NEXT_PUBLIC_APP_URL when set', () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://duecker-medizintechnik.de/';
+    const req = mockRequest({
+      'x-forwarded-host': 'localhost:3000',
+      'x-forwarded-proto': 'https',
+    });
+    expect(getRedirectOriginFromRequest(req)).toBe(
+      'https://duecker-medizintechnik.de',
+    );
+  });
+
+  it('uses x-forwarded-host and x-forwarded-proto when env URL is unset', () => {
+    process.env.NEXT_PUBLIC_APP_URL = '';
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    const req = mockRequest({
+      'x-forwarded-host': 'duecker-medizintechnik.de',
+      'x-forwarded-proto': 'https',
+    });
+    expect(getRedirectOriginFromRequest(req)).toBe(
+      'https://duecker-medizintechnik.de',
+    );
+  });
+
+  it('defaults forwarded proto to https when missing', () => {
+    process.env.NEXT_PUBLIC_APP_URL = '';
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    const req = mockRequest({
+      'x-forwarded-host': 'example.com',
+    });
+    expect(getRedirectOriginFromRequest(req)).toBe('https://example.com');
+  });
+
+  it('falls back to getBaseUrl when no forwarded host', () => {
+    process.env.NEXT_PUBLIC_APP_URL = '';
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    jest.replaceProperty(process, 'env', {
+      ...process.env,
+      NODE_ENV: 'development',
+      NEXT_PUBLIC_APP_URL: undefined,
+    });
+    const req = mockRequest({});
+    expect(getRedirectOriginFromRequest(req)).toBe('http://localhost:3000');
+  });
+});

--- a/src/lib/get-base-url.ts
+++ b/src/lib/get-base-url.ts
@@ -1,3 +1,5 @@
+import type { NextRequest } from 'next/server';
+
 /**
  * Site origin (no trailing slash). Used for sitemap/robots and other absolute URLs.
  * Set `NEXT_PUBLIC_APP_URL` in production (e.g. Coolify) to the public origin, e.g.
@@ -14,3 +16,34 @@ export const getBaseUrl = () => {
 
   return 'http://localhost:3000';
 };
+
+/**
+ * Origin for absolute redirects from Route Handlers. Prefer `NEXT_PUBLIC_APP_URL`,
+ * then proxy headers (Coolify/Traefik), then {@link getBaseUrl}.
+ *
+ * `new URL(path, request.url)` is wrong behind a reverse proxy: `request.url`
+ * often reflects the internal host (e.g. `https://localhost:3000`), which breaks
+ * Directus Live Preview when the iframe loads the public domain first.
+ */
+export function getRedirectOriginFromRequest(request: NextRequest): string {
+  const fromEnv = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '');
+  if (fromEnv) return fromEnv;
+
+  const xfHost = request.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
+  const xfProto = request.headers
+    .get('x-forwarded-proto')
+    ?.split(',')[0]
+    ?.trim();
+
+  if (xfHost) {
+    const proto =
+      xfProto === 'http' || xfProto === 'https' ? xfProto : 'https';
+    try {
+      return new URL(`${proto}://${xfHost}`).origin;
+    } catch {
+      // fall through
+    }
+  }
+
+  return getBaseUrl();
+}

--- a/src/lib/get-base-url.ts
+++ b/src/lib/get-base-url.ts
@@ -36,8 +36,7 @@ export function getRedirectOriginFromRequest(request: NextRequest): string {
     ?.trim();
 
   if (xfHost) {
-    const proto =
-      xfProto === 'http' || xfProto === 'https' ? xfProto : 'https';
+    const proto = xfProto === 'http' || xfProto === 'https' ? xfProto : 'https';
     try {
       return new URL(`${proto}://${xfHost}`).origin;
     } catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Directus Live Preview loads `https://duecker-medizintechnik.de/api/draft?…` in the iframe, but the app responded with a redirect to `https://localhost:3000/de/newsroom/…`.

## Root cause

`app/api/draft/route.ts` and `app/api/draft/disable/route.ts` used `NextResponse.redirect(new URL(path, request.url))`. Behind Coolify (and similar proxies), `request.url` often reflects the **internal** origin the edge forwards to (e.g. `https://localhost:3000`), not the public host the browser used.

## Solution

- Add `getRedirectOriginFromRequest(request)` in `src/lib/get-base-url.ts`: prefer `NEXT_PUBLIC_APP_URL`, then `X-Forwarded-Host` + `X-Forwarded-Proto`, then `getBaseUrl()`.
- Use that origin when building redirect `Location` URLs.
- Document in `docs/directus-setup.md`, README, and `.env.example`.
- Add Jest tests for the helper (mocked `NextRequest` headers).

## Ops note

Setting `NEXT_PUBLIC_APP_URL=https://duecker-medizintechnik.de` in Coolify for the Next.js service is still recommended for canonical URLs and as the most explicit fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8472dfc4-e949-4179-8ca1-484d95d1d12c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8472dfc4-e949-4179-8ca1-484d95d1d12c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed draft preview redirects when deployed behind reverse proxies (e.g., Coolify).
  * Improved redirect origin detection to properly handle proxy headers.

* **Documentation**
  * Added setup instructions for reverse proxy environments.
  * Documented required `NEXT_PUBLIC_APP_URL` environment variable.
  * Added troubleshooting guide for preview redirect issues in proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->