### PR TITLE
fix(directus): correct data-directus format for Visual Editor

### DIFF
--- a/src/lib/__tests__/directus-visual-editor.test.ts
+++ b/src/lib/__tests__/directus-visual-editor.test.ts
@@ -1,0 +1,24 @@
+import { setVisualEditorAttr } from '@/lib/directus-visual-editor';
+
+describe('setVisualEditorAttr', () => {
+  it('formats attributes for @directus/visual-editing (semicolon-separated key:value)', () => {
+    expect(
+      setVisualEditorAttr({
+        collection: 'posts',
+        item: 42,
+        fields: 'title',
+        mode: 'popover',
+      }),
+    ).toBe('collection:posts;item:42;fields:title;mode:popover');
+  });
+
+  it('joins multiple field names with commas', () => {
+    expect(
+      setVisualEditorAttr({
+        collection: 'posts',
+        item: 'x',
+        fields: ['title', 'excerpt'],
+      }),
+    ).toBe('collection:posts;item:x;fields:title,excerpt');
+  });
+});

--- a/src/lib/directus-visual-editor.ts
+++ b/src/lib/directus-visual-editor.ts
@@ -5,8 +5,8 @@
  *  - keep `setAttr` available for SSR templates without pulling the runtime
  *    code into server bundles.
  *
- * `setAttr` is a pure helper (it just builds a JSON string) so we re-export
- * it for both server and client components.
+ * `setVisualEditorAttr` is a pure string builder so it can run on the server
+ * without importing the client-only Visual Editor runtime.
  */
 
 import { directusUrl } from '@/constant/env';
@@ -21,22 +21,26 @@ export type VisualEditorAttr = {
 };
 
 /**
- * Builds the value for a `data-directus` attribute. We use a pure JSON
- * implementation so it can run on the server without importing the
- * client-only Visual Editor runtime.
+ * Builds the value for a `data-directus` attribute.
+ *
+ * `@directus/visual-editing` parses this with `editAttrToObject`, which only
+ * understands semicolon-separated `key:value` pairs (see `setAttr` /
+ * `objectToEditAttr` in that package). JSON strings are not parsed, so the
+ * parent Directus UI never receives a valid edit config and falls back to
+ * legacy `[data-field="…"]` lookups that never match.
  */
 export function setVisualEditorAttr(attr: VisualEditorAttr): string {
-  const payload: Record<string, unknown> = {
-    collection: attr.collection,
-    item: attr.item,
-  };
+  const segments: string[] = [];
+  segments.push(`collection:${attr.collection}`);
+  segments.push(`item:${String(attr.item)}`);
   if (attr.fields !== undefined) {
-    payload.fields = Array.isArray(attr.fields) ? attr.fields : [attr.fields];
+    const fields = Array.isArray(attr.fields) ? attr.fields : [attr.fields];
+    segments.push(`fields:${fields.join(',')}`);
   }
   if (attr.mode) {
-    payload.mode = attr.mode;
+    segments.push(`mode:${attr.mode}`);
   }
-  return JSON.stringify(payload);
+  return segments.join(';');
 }
 
 let isApplied = false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Visual Editor in Directus was looking for `[data-field="title"]` and similar because the iframe never received a valid edit configuration from the page.

`@directus/visual-editing` parses `data-directus` with `editAttrToObject`, which only understands **semicolon-separated** `key:value` pairs (the same format as the package’s `setAttr` helper). Our `setVisualEditorAttr` was outputting **JSON**, which that parser does not understand, so `collection`, `item`, and `fields` were never set on the overlay items.

## Changes

- `setVisualEditorAttr` now builds `collection:…;item:…;fields:…;mode:…` like the official library.
- Added unit tests for the string format.

## Note on console errors

The `de-DE.js` / TinyMCE `Unexpected token '<'` error is separate (usually a bad locale script URL or HTML error page returned instead of JS). If rich-text editing inside Directus still breaks after deploy, inspect that request in the Network tab; it is not addressed by this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4884506-566f-4930-8085-e0786e8ee1a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4884506-566f-4930-8085-e0786e8ee1a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

