### PR TITLE
chore: root config cleanup (Sentry config under src)

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,13 +1,1 @@
-// This file configures the initialization of Sentry on the client.
-// The config you add here will be used whenever a users loads a page in their browser.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-import * as Sentry from '@sentry/nextjs';
-
-import packageJson from '/package.json';
-
-Sentry.init({
-  dsn: 'https://65f5a4b32dec025660814ac1469ba53a@o4506781842145280.ingest.us.sentry.io/4507729952833536',
-  environment: process.env.NODE_ENV,
-  release: packageJson.version,
-});
+export * from './src/sentry/client';

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,16 +1,1 @@
-// This file configures the initialization of Sentry for edge features (middleware, edge routes, and so on).
-// The config you add here will be used whenever one of the edge features is loaded.
-// Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: 'https://65f5a4b32dec025660814ac1469ba53a@o4506781842145280.ingest.us.sentry.io/4507729952833536',
-
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+export * from './src/sentry/edge';

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,18 +1,1 @@
-// This file configures the initialization of Sentry on the server.
-// The config you add here will be used whenever the server handles a request.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: 'https://65f5a4b32dec025660814ac1469ba53a@o4506781842145280.ingest.us.sentry.io/4507729952833536',
-
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-
-  // Uncomment the line below to enable Spotlight (https://spotlightjs.com)
-  // spotlight: process.env.NODE_ENV === 'development',
-});
+export * from './src/sentry/server';

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,11 +1,11 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    await import('../sentry.server.config');
+    await import('./sentry/server');
     const { assertDirectusEnv } = await import('@/lib/env-assertions');
     assertDirectusEnv();
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {
-    await import('../sentry.edge.config');
+    await import('./sentry/edge');
   }
 }

--- a/src/sentry/client.ts
+++ b/src/sentry/client.ts
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/nextjs';
+
+import packageJson from '../../package.json';
+
+Sentry.init({
+  dsn: 'https://65f5a4b32dec025660814ac1469ba53a@o4506781842145280.ingest.us.sentry.io/4507729952833536',
+  environment: process.env.NODE_ENV,
+  release: packageJson.version,
+});
+

--- a/src/sentry/edge.ts
+++ b/src/sentry/edge.ts
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: 'https://65f5a4b32dec025660814ac1469ba53a@o4506781842145280.ingest.us.sentry.io/4507729952833536',
+
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1,
+
+  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  debug: false,
+});
+

--- a/src/sentry/server.ts
+++ b/src/sentry/server.ts
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: 'https://65f5a4b32dec025660814ac1469ba53a@o4506781842145280.ingest.us.sentry.io/4507729952833536',
+
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1,
+
+  // Setting this option to true will print useful information to the console while you're setting up Sentry.
+  debug: false,
+});
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description & Technical Solution

This cleans up repository root config clutter by moving Sentry runtime initialization into `src/sentry/*`.

The root-level `sentry.client.config.ts`, `sentry.server.config.ts`, and `sentry.edge.config.ts` are kept as minimal re-export stubs so Next/Sentry default file discovery continues to work, while the actual implementation lives under `src/`.

Updated `src/instrumentation.ts` to import the new module locations.

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] Already rebased against main branch.

# Screenshots

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2df75e0a-8caa-4835-9e07-93095ad9154e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2df75e0a-8caa-4835-9e07-93095ad9154e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

